### PR TITLE
fix angular 11+ compilation type error

### DIFF
--- a/src/main/webapp/app/core/insights/application-insights.service.ts
+++ b/src/main/webapp/app/core/insights/application-insights.service.ts
@@ -16,7 +16,10 @@ export class ApplicationInsightsService {
 
   constructor(private router: Router) {
     this.appInsights.loadAppInsights();
-    this.routerSubscription = this.router.events.pipe(filter(event => event instanceof ResolveEnd)).subscribe((event: ResolveEnd) => {
+    this.routerSubscription = this.router.events.pipe(
+            filter((event): event is ResolveEnd => event instanceof ResolveEnd)
+          )
+          .subscribe(event => {
       const activatedComponent = this.getActivatedComponent(event.state.root);
       if (activatedComponent) {
         this.logPageView(`${activatedComponent.name} ${this.getRouteTemplate(event.state.root)}`, event.urlAfterRedirects);


### PR DESCRIPTION
This PR is to fix a compilation error related to types in the constructor subscription to route event.